### PR TITLE
Upgrade CI to go1.11 now that GAE supports it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: go
 go:
-- 1.6 # Latest GAE standard, unfortunately.
+- 1.11 # Latest GAE standard
 env:
   global:
   - GAE_SDK_URL=https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.48.zip
@@ -18,4 +18,4 @@ install:
 script:
 - goapp test -v ./...
 - go vet ./...
-- "go get github.com/golang/lint/golint && golint ./..."
+- "go get golang.org/x/lint/golint && golint ./..."


### PR DESCRIPTION
Also, update the path to golint now that we can.
Closes #10 