### PR TITLE
Update CI to use the latest GAE SDK

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ go:
 - 1.11 # Latest GAE standard
 env:
   global:
-  - GAE_SDK_URL=https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.48.zip
+  - GAE_SDK_URL=https://storage.googleapis.com/appengine-sdks/featured/go_appengine_sdk_linux_amd64-1.9.68.zip
   - PATH=$HOME/go_appengine:$PATH
 cache:
   directories:


### PR DESCRIPTION
Bump GAE to v1.9.68